### PR TITLE
Remove asu_search_module form

### DIFF
--- a/headers/default_aspnet.shtml
+++ b/headers/default_aspnet.shtml
@@ -73,18 +73,6 @@
                 Search
             </h2>
             <div id="asu_search_module">
-			<form target="_top" action="https://search.asu.edu/search" method="get" name="gs">
-				<label class="hidden" for="asu_search_box">Search</label>
-				<input name="site" value="default_collection" type="hidden" />
-				<input name="q" class="asu_search_box" id="asu_search_box" placeholder="Search" autocomplete="off" type="text">
-				<input type="submit" value="Search" title="Search" class="asu_search_button" />	
-				<input name="sort" value="date:D:L:d1" type="hidden" /> 
-				<input name="output" value="xml_no_dtd" type="hidden" /> 
-				<input name="ie" value="UTF-8" type="hidden" /> 
-				<input name="oe" value="UTF-8" type="hidden" /> 
-				<input name="client" value="asu_frontend" type="hidden" /> 
-				<input name="proxystylesheet" value="asu_frontend" type="hidden" />
-			</form>
 			</div>
         </div>
     </div>


### PR DESCRIPTION
Removed the hard-coded form from the asu_search_module div
in headers/default_aspnet.shtml.  Form is added by asuthemes js file.  
Should prevent our .NET apps from having two search boxes.
